### PR TITLE
Allow click-drag to be disabled/enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Emitted with the following info:
 - `clientX` - the final mouse event's `clientX` value
 - `clientY` - the final mouse event's `clientY` value
 
+### Applying click-drag conditionally
+You can conditionally apply `click-drag` behaviors by specifying an `enabled`
+attribute in your `click-drag` property:
+
+```javascript
+...
+<a-sphere click-drag="enabled: false" position="0 1.25 -1" radius="1.25" color="#EF2D5E"></a-sphere>
+...
+```
+
 ### Installation
 
 #### Browser

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -9,7 +9,7 @@
       <a-sphere click-drag position="0 1.25 -1" radius="1.25" color="#EF2D5E"></a-sphere>
       <a-box click-drag position="-1 0.5 1" rotation="0 45 0" width="1" height="1" depth="1"  color="#4CC3D9"></a-box>
       <a-cylinder click-drag position="1 0.75 1" radius="0.5" height="1.5" color="#FFC65D"></a-cylinder>
-      <a-plane rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
+      <a-plane click-drag="enabled: false" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
 
       <a-sky color="#ECECEC"></a-sky>
 

--- a/src/index.js
+++ b/src/index.js
@@ -456,6 +456,11 @@ const {didMount, didUnmount} = (function getDidMountAndUnmount() {
       const {depth, offset, element} = selectItem(THREE, componentName, camera, clientX, clientY);
 
       if (element) {
+        // If click-drag is not enabled, return.
+        if (element.getAttribute('click-drag').enabled === 'false') {
+          return;
+        }
+
         // Can only drag one item at a time, so no need to check if any
         // listener is already set up
         let removeDragItemListeners = dragItem(


### PR DESCRIPTION
Hey there! Thanks for this awesome component, it's incredibly useful!

I need to apply `click-drag` behaviors conditionally, and so I forked and added a small change that allows `click-drag` to be disabled by setting the `click-drag` attribute to `enabled: false`. There are other ways of accomplishing this, so I'm open to other options, but this was the cleanest in my case, so I thought I'd PR it.

## Steps to test
- [ ] Check out this branch.
- [ ] Start the dev server (`yarn start` or `npm run start`).
- [ ] Navigate to the basic example.
- [ ] Note that you can click/drag the sphere, cylinder, and cube, but not the plane.