### PR TITLE
Fix ".applyProjection() has been removed."

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ const {unproject} = (function unprojectFunction() {
 
       initialized = initialized || initialize(THREE);
 
-      vector.applyProjection(matrix.getInverse(threeCamera.projectionMatrix));
+      vector.applyMatrix4(matrix.getInverse(threeCamera.projectionMatrix));
 
       return localToWorld(THREE, threeCamera, vector);
 


### PR DESCRIPTION
Console warning when using the NPM module:
```
THREE.Vector3: .applyProjection() has been removed. Use .applyMatrix4( m ) instead.
```
This commit fixes the error